### PR TITLE
Fix for UnicodeDecodeError when optimizing multiple files (i.e. when using StringIO) and at least one of the files contains unicode characters

### DIFF
--- a/django_static/templatetags/django_static.py
+++ b/django_static/templatetags/django_static.py
@@ -507,7 +507,7 @@ def _static_file(filename,
         # Then we expect to be able to modify the content and we will
         # definitely need to write a new file.
         if is_combined_files:
-            content = new_file_content.getvalue()
+            content = new_file_content.getvalue().decode('utf-8')
         else:
             #content = open(filepath).read()
             content = codecs.open(filepath, 'r', 'utf-8').read()


### PR DESCRIPTION
Fixed unicode decode error when optimizing combined files that contain unicode

new_file_content.getvalue() returns a str, but codecs.open(new_filepath, 'w', 'utf-8').write() expects unicode, else it b0rks
