### PR TITLE
Use 1.3 contrib.staticfiles' finders to avoid needing to run collectstatic in dev mode

### DIFF
--- a/django_static/templatetags/django_static.py
+++ b/django_static/templatetags/django_static.py
@@ -632,6 +632,16 @@ def _find_filepath_in_roots(filename):
         filepath = _filename2filepath(filename, root)
         if os.path.isfile(filepath):
             return filepath, root
+    # havent found it in DJANGO_STATIC_MEDIA_ROOTS look for apps' files if we're
+    #  in DEBUG mode
+    if settings.DEBUG:
+        try:
+            from django.contrib.staticfiles import finders
+            absolute_path = finders.find(filename)
+            root, filepath = os.path.split(absolute_path)
+            return absolute_path, root
+        except ImportError:
+            pass
     return None, None
 
 def _filename2filepath(filename, media_root):


### PR DESCRIPTION
I know you can turn django-static off during development, but sometimes you want to find whatever files are not being processed by it, so you need it on, and if collectstatic hasn't been run yet, django-static fails to find it.

If `django.contrib.staticfiles.finders` is available, this patch will use it (after failing to find a file with current django-static behavior)  to find the wanted files, presumably in the apps' directories.
