### PR TITLE
Added a workaround for a bug with new closure compiler versions

### DIFF
--- a/django_static/templatetags/django_static.py
+++ b/django_static/templatetags/django_static.py
@@ -747,6 +747,11 @@ def _run_closure_compiler(jscode):
     proc = Popen(cmd, shell=True, stdout=PIPE, stdin=PIPE, stderr=PIPE)
     try:
         (stdoutdata, stderrdata) = proc.communicate(jscode)
+        if stderrdata:
+            # Check if there are real errors.
+            if re.search('[1-9]\d* error(s)', stderrdata) is None:
+                # Suppress the loud stderr output of closure compiler.
+                stderrdata = None
     except OSError, msg: # pragma: no cover
         # see comment on OSErrors inside _run_yui_compressor()
         stderrdata = \


### PR DESCRIPTION
django-static do not work with latest closure compiler because it is talking too much to stderr
I have not found a way to stop this, so added a fix for this problem.