### PR TITLE
Adds support for overriding combine_filenames_generator

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -221,6 +221,75 @@ python function. Here's the skeleton for that function::
   def filename_generator(file_parts, new_m_time):
       return ''.join([file_parts[0], '.%s' % new_m_time, file_parts[1]])
 
+
+Advanced configuration with DJANGO_STATIC_COMBINE_FILENAMES_GENERATOR
+---------------------------------------------------------------------
+
+By default, django-static generates filenames for your combined files 
+using timestamps. You can use your own filename generating function
+by setting it in settings, like so::
+
+        DJANGO_STATIC_COMBINE_FILENAMES_GENERATOR = 'myapp.combine_filenames'
+
+This is expected to be the equivalent of this import statement::
+
+        from myapp import combine_filenames
+
+Where ``myapp`` is a python module, and ``combine_filenames`` is a regular
+python function. Here's the skeleton for that function::
+
+  """Return a new filename to use as the combined file name for a
+  bunch of files.
+  A precondition is that they all have the same file extension
+
+  Given that the list of files can have different paths, we aim to use the
+  most common path.
+
+  Example:
+    /somewhere/else/foo.js
+    /somewhere/bar.js
+    /somewhere/different/too/foobar.js
+  The result will be
+    /somewhere/foo_bar_foobar.js
+
+  Another thing to note, if the filenames have timestamps in them, combine
+  them all and use the highest timestamp.
+
+  """
+  path = None
+  names = []
+  extension = None
+  timestamps = []
+  for filename in filenames:
+      name = os.path.basename(filename)
+      if not extension:
+          extension = os.path.splitext(name)[1]
+      elif os.path.splitext(name)[1] != extension:
+          raise ValueError("Can't combine multiple file extensions")
+
+      for each in re.finditer('\.\d{10}\.', name):
+          timestamps.append(int(each.group().replace('.','')))
+          name = name.replace(each.group(), '.')
+      name = os.path.splitext(name)[0]
+      names.append(name)
+
+      if path is None:
+          path = os.path.dirname(filename)
+      else:
+          if len(os.path.dirname(filename)) < len(path):
+              path = os.path.dirname(filename)
+
+
+  new_filename = '_'.join(names)
+  if timestamps:
+      new_filename += ".%s" % max(timestamps)
+
+  new_filename = new_filename[:max_length]
+  new_filename += extension
+
+  return os.path.join(path, new_filename)
+
+
 Compression Filters
 -------------------
 

--- a/README.rst
+++ b/README.rst
@@ -226,8 +226,8 @@ Advanced configuration with DJANGO_STATIC_COMBINE_FILENAMES_GENERATOR
 ---------------------------------------------------------------------
 
 By default, django-static generates filenames for your combined files 
-using timestamps. You can use your own filename generating function
-by setting it in settings, like so::
+by concatenating the file names. You can also use your own filename 
+generating function by setting it in settings, like so::
 
         DJANGO_STATIC_COMBINE_FILENAMES_GENERATOR = 'myapp.combine_filenames'
 
@@ -238,24 +238,6 @@ This is expected to be the equivalent of this import statement::
 Where ``myapp`` is a python module, and ``combine_filenames`` is a regular
 python function. Here's the skeleton for that function::
 
-  """Return a new filename to use as the combined file name for a
-  bunch of files.
-  A precondition is that they all have the same file extension
-
-  Given that the list of files can have different paths, we aim to use the
-  most common path.
-
-  Example:
-    /somewhere/else/foo.js
-    /somewhere/bar.js
-    /somewhere/different/too/foobar.js
-  The result will be
-    /somewhere/foo_bar_foobar.js
-
-  Another thing to note, if the filenames have timestamps in them, combine
-  them all and use the highest timestamp.
-
-  """
   path = None
   names = []
   extension = None

--- a/django_static/templatetags/django_static.py
+++ b/django_static/templatetags/django_static.py
@@ -692,9 +692,9 @@ def _filename2filepath(filename, media_root):
 
 
 
-def _combine_filenames(filenames, max_length=40):
+def default_combine_filenames_generator(filenames, max_length=40):
     """Return a new filename to use as the combined file name for a
-    bunch files.
+    bunch of files.
     A precondition is that they all have the same file extension
 
     Given that the list of files can have different paths, we aim to use the
@@ -743,6 +743,18 @@ def _combine_filenames(filenames, max_length=40):
     new_filename += extension
 
     return os.path.join(path, new_filename)
+
+
+def _load_combine_filenames_generator():
+    combine_filenames_generator = getattr(settings, 'DJANGO_STATIC_COMBINE_FILENAMES_GENERATOR', None)
+    if combine_filenames_generator:
+        from django.utils.importlib import import_module
+        _module_name, _function_name = combine_filenames_generator.rsplit('.', 1)
+        combine_filenames_generator_module = import_module(_module_name)
+        return getattr(combine_filenames_generator_module, _function_name)
+    return default_combine_filenames_generator
+
+_combine_filenames = _load_combine_filenames_generator()
 
 
 CSS = 'css'


### PR DESCRIPTION
Hey there,

This PR just allows users to override `combine_filenames_generator` in addition to `filename_generator`.

Rationale: my build process always results in new modified times, so I'd like to use file hashes instead. 

Docs included, let me know if you need changes!

Thanks,
-Steven